### PR TITLE
Support subscription state replication for geo-replication

### DIFF
--- a/docker-image/pom.xml
+++ b/docker-image/pom.xml
@@ -25,37 +25,37 @@
    <artifactId>docker-image</artifactId>
    <packaging>pom</packaging>
    <name>NiFi Pulsar Connectors :: Docker Image</name>
-   
+
     <build>
-	  <plugins>
-	    <plugin>
-		   <groupId>io.fabric8</groupId>
-           <artifactId>docker-maven-plugin</artifactId>
-           <configuration>
-             <images>
-                <image>
-                   <name>streamnative/nifi</name>
-                   <build> 
-                     <dockerFileDir>nifi</dockerFileDir>
-                     <assembly>
-                       <targetDir>/connectors</targetDir>
-                       <mode>dir</mode>
-                       <descriptor>nifi/assembly.xml</descriptor>
-                     </assembly>
-                   </build>
-               </image>
-             </images>
-           </configuration>
-           <executions>
-             <execution>
-               <phase>package</phase>
-                <goals>
-                   <goal>build</goal>
-               </goals>
-             </execution>
-           </executions>
-        </plugin>
-      </plugins>
+        <plugins>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.40.2</version>
+                <configuration>
+                    <images>
+                        <image>
+                            <name>streamnative/nifi</name>
+                            <build>
+                                <dockerFileDir>nifi</dockerFileDir>
+                                <assembly>
+                                    <targetDir>/connectors</targetDir>
+                                    <mode>dir</mode>
+                                    <descriptor>nifi/assembly.xml</descriptor>
+                                </assembly>
+                            </build>
+                        </image>
+                    </images>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
-     
 </project>

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/mocks/MockPulsarClientService.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/mocks/MockPulsarClientService.java
@@ -26,18 +26,32 @@ import java.util.concurrent.TimeUnit;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.pulsar.PulsarClientService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
-import org.apache.pulsar.client.api.*;
+import org.apache.pulsar.client.api.CompressionType;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.MessageRoutingMode;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerBuilder;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.api.TypedMessageBuilder;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 
 @SuppressWarnings("unchecked")
@@ -99,6 +113,7 @@ public class MockPulsarClientService<T> extends AbstractControllerService implem
         when(mockConsumerBuilder.receiverQueueSize(anyInt())).thenReturn(mockConsumerBuilder);
         when(mockConsumerBuilder.subscriptionType(any(SubscriptionType.class))).thenReturn(mockConsumerBuilder);
         when(mockConsumerBuilder.subscriptionInitialPosition(any(SubscriptionInitialPosition.class))).thenReturn(mockConsumerBuilder);
+        when(mockConsumerBuilder.replicateSubscriptionState(anyBoolean())).thenReturn(mockConsumerBuilder);
 
         when(mockSchema.getType()).thenReturn(SchemaType.BYTES);
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     </issueManagement>
     
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Dependency versions -->
     	<commons-collections4.version>4.2</commons-collections4.version>
     	<commons-compress.version>1.21</commons-compress.version>


### PR DESCRIPTION
As stated at https://pulsar.apache.org/docs/administration-geo/#replicated-subscriptions, in order to restart the consumers at the failure point from a backup broker in geo-replication mode, subscription state replication has to be enabled.

This pull request supports the consumer option to enable subscription state replication.