### PR TITLE
build: migrate Maven Central publishing to the Sonatype Central Portal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         run: mvn -B -ntp versions:set -DnewVersion="${GITHUB_REF_NAME#v}" -DgenerateBackupPoms=false -DprocessAllModules=true
 
       # Build the NAR artifacts. GPG signing and the docker-image module are skipped
-      # here; enable the opt-in jobs below if you want signed Central deploys / images.
+      # here; the docker and central-deploy jobs below handle images and Central.
       - name: Build NAR artifacts
         run: mvn -B -ntp clean package -Dgpg.skip=true -pl '!docker-image'
 
@@ -110,30 +110,39 @@ jobs:
           docker push "${IMAGE}:${VERSION}"
           docker push "${IMAGE}:latest"
 
-  # ---------------------------------------------------------------------------
-  # OPT-IN: deploy signed artifacts to Sonatype OSSRH / Maven Central.
-  # Requires repo secrets: OSSRH_USERNAME, OSSRH_PASSWORD,
-  # MAVEN_GPG_PRIVATE_KEY, MAVEN_GPG_PASSPHRASE.
-  # ---------------------------------------------------------------------------
-  # central-deploy:
-  #   name: Deploy to Maven Central
-  #   runs-on: ubuntu-latest
-  #   needs: release
-  #   steps:
-  #     - uses: actions/checkout@v6
-  #     - uses: actions/setup-java@v5
-  #       with:
-  #         distribution: temurin
-  #         java-version: '21'
-  #         cache: maven
-  #         server-id: ossrh
-  #         server-username: OSSRH_USERNAME
-  #         server-password: OSSRH_PASSWORD
-  #         gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-  #         gpg-passphrase: MAVEN_GPG_PASSPHRASE
-  #     - name: Publish
-  #       run: mvn -B -ntp clean deploy -DskipTests
-  #       env:
-  #         OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-  #         OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-  #         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+  # Deploy signed artifacts to Maven Central via the Sonatype Central Portal.
+  # Uses org-level secrets already shared with this repo: SONATYPE_USERNAME /
+  # SONATYPE_PASSWORD are a Central Portal token (server id `central`), and
+  # GPG_PRIVATE_KEY / GPG_PRIVATE_KEY_PASSPHRASE sign the artifacts.
+  central-deploy:
+    name: Deploy to Maven Central
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+          server-id: central
+          server-username: SONATYPE_USERNAME
+          server-password: SONATYPE_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PRIVATE_KEY_PASSPHRASE
+
+      # The git tag is authoritative for the published version, same as above.
+      - name: Stamp version from tag
+        if: github.ref_type == 'tag'
+        run: mvn -B -ntp versions:set -DnewVersion="${GITHUB_REF_NAME#v}" -DgenerateBackupPoms=false -DprocessAllModules=true
+
+      # docker-image is a packaging-only module and must not go to Central.
+      - name: Publish to Maven Central
+        run: mvn -B -ntp clean deploy -DskipTests -pl '!docker-image'
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}

--- a/pom.xml
+++ b/pom.xml
@@ -60,17 +60,6 @@
         <url>https://github.com/david-streamlio/pulsar-nifi-bundle/tree/main</url>
     </scm>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
-
     <mailingLists>
         <mailingList>
             <name>Dev</name>
@@ -110,7 +99,7 @@
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
         <nifi-nar-maven-plugin.version>2.3.0</nifi-nar-maven-plugin.version>
-        <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
         <maven-versions-plugin.version>2.5</maven-versions-plugin.version>
 
         <maven.deploy.skip>true</maven.deploy.skip>
@@ -191,15 +180,27 @@
                 </configuration>
             </plugin>
 
+            <!-- The Apache NiFi parent pom injects a nexus-staging deploy aimed at
+                 repository.apache.org; disable it so central-publishing owns the
+                 deploy phase. -->
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>${nexus-staging-maven-plugin.version}</version>
+                <extensions>false</extensions>
+                <configuration>
+                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>${central-publishing-maven-plugin.version}</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>published</waitUntil>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
## Why

The pom still deploys via `nexus-staging-maven-plugin` to `s01.oss.sonatype.org`, which was decommissioned with OSSRH in 2025. The v2.1.1 release (Nov 2025) tagged and branched fine but **never reached Maven Central** — the deploy failure was silently swallowed by `mvn deploy || true` in the old release tooling. The latest version on Central is still 2.1.0.

This unblocks publishing 2.9.0 (matching `nifi.version` 2.9.0) to Maven Central.

## What

- **pom.xml**
  - Replace `nexus-staging-maven-plugin` (server id `ossrh`, dead s01 URLs) with `org.sonatype.central:central-publishing-maven-plugin` 0.11.0 (server id `central`, `autoPublish`).
  - Remove the s01 `<distributionManagement>` block.
  - Explicitly disable the nexus-staging deploy that the Apache NiFi parent pom injects (aimed at `repository.apache.org`) — with our local declaration gone it would otherwise hijack the deploy phase.
- **release.yml**
  - Enable the previously commented-out `central-deploy` job. It uses the **org-level secrets already shared with this repo**: `SONATYPE_USERNAME`/`SONATYPE_PASSWORD` (Central Portal token, same server id `central` streamnative-ci uses) and `GPG_PRIVATE_KEY`/`GPG_PRIVATE_KEY_PASSPHRASE` for signing. No new secrets required.
  - The job runs on `v*` tag pushes alongside the existing GitHub-release and GHCR-image jobs, stamps the pom version from the tag, and excludes the `docker-image` module from the Central bundle.

## Verification

- `mvn clean install -DskipTests -Dgpg.skip=true -pl '!docker-image'` passes with the migrated pom.
- `mvn deploy -DskipPublishing=true ...` dry run: `central-publishing:publish` owns the deploy phase for **all six modules** (parent pom included — the root `maven.deploy.skip=true` doesn't affect the new plugin), with no nexus-staging execution.

## Release plan (after merge)

Push tag `v2.9.0` → `release.yml` produces the GitHub release with NARs, the `ghcr.io/streamnative/nifi` image, and the signed Maven Central publish of 2.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)